### PR TITLE
fixed lower case and ident/value issue in where.setter on Device

### DIFF
--- a/nest/nest.py
+++ b/nest/nest.py
@@ -293,10 +293,11 @@ class Device(NestBase):
 
     @where.setter
     def where(self, value):
+        value = value.lower()
         ident = self.structure.wheres.get(value)
 
         if ident is None:
-            self.structure.add_where(ident)
+            self.structure.add_where(value)
             ident = self.structure.wheres[value]
 
         self._set('device', {'where_id': ident})


### PR DESCRIPTION
Fixed where.setter on Device to lower case value before searching dictionary and fed value into the add_where method on Structure rather than ident.