### PR TITLE
Advanced Structure and Device properties

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ You can import the module as `nest`.
         print ' dr_reminder_enabled            : %s' % structure.dr_reminder_enabled
         print ' emergency_contact_description  : %s' % structure.emergency_contact_description
         print ' emergency_contact_type         : %s' % structure.emergency_contact_type
+        print ' emergency_contact_phone        : %s' % structure.emergency_contact_phone
         print ' enhanced_auto_away_enabled     : %s' % structure.enhanced_auto_away_enabled
         print ' eta_preconditioning_active     : %s' % structure.eta_preconditioning_active
         print ' house_type                     : %s' % structure.house_type

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,6 @@ You can import the module as `nest`.
         print ' structure_area                 : %s' % structure.structure_area
 
     # Access advanced device properties:
-
         for device in structure.devices:
             print '        Device: %s' % device.name
             print '        Where: %s' % device.where

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,22 @@ You can import the module as `nest`.
             print '        Device: %s' % device.name
             print '            Temp: %0.1f' % device.temperature
 
+    # Access advanced structure properties:
+    for structure in napi.structures:
+        print 'Structure   : %s' % structure.name
+        print ' Postal Code                    : %s' % structure.postal_code
+        print ' Country                        : %s' % structure.country_code
+        print ' dr_reminder_enabled            : %s' % structure.dr_reminder_enabled
+        print ' emergency_contact_description  : %s' % structure.emergency_contact_description
+        print ' emergency_contact_type         : %s' % structure.emergency_contact_type
+        print ' enhanced_auto_away_enabled     : %s' % structure.enhanced_auto_away_enabled
+        print ' eta_preconditioning_active     : %s' % structure.eta_preconditioning_active
+        print ' house_type                     : %s' % structure.house_type
+        print ' hvac_safety_shutoff_enabled    : %s' % structure.hvac_safety_shutoff_enabled
+        print ' num_thermostats                : %s' % structure.num_thermostats
+        print ' measurement_scale              : %s' % structure.measurement_scale
+        print ' renovation_date                : %s' % structure.renovation_date
+        print ' structure_area                 : %s' % structure.structure_area
 
     # The Nest object can also be used as a context manager
     with nest.Nest(username, password) as napi:

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,37 @@ You can import the module as `nest`.
         print ' renovation_date                : %s' % structure.renovation_date
         print ' structure_area                 : %s' % structure.structure_area
 
+    # Access advanced device properties:
+
+        for device in structure.devices:
+            print '        Device: %s' % device.name
+            print '        Where: %s' % device.where
+            print '            Mode     : %s' % device.mode
+            print '            Fan      : %s' % device.fan
+            print '            Temp     : %0.1fC' % device.temperature
+            print '            Humidity : %0.1f%%' % device.humidity
+            print '            Target   : %0.1fC' % device.target
+            print '            Away Heat: %0.1fC' % device.away_temperature[0]
+            print '            Away Cool: %0.1fC' % device.away_temperature[1]
+
+            print '            hvac_ac_state         : %s' % device.hvac_ac_state
+            print '            hvac_cool_x2_state    : %s' % device.hvac_cool_x2_state
+            print '            hvac_heater_state     : %s' % device.hvac_heater_state
+            print '            hvac_aux_heater_state : %s' % device.hvac_aux_heater_state
+            print '            hvac_heat_x2_state    : %s' % device.hvac_heat_x2_state
+            print '            hvac_heat_x3_state    : %s' % device.hvac_heat_x3_state
+            print '            hvac_alt_heat_state   : %s' % device.hvac_alt_heat_state
+            print '            hvac_alt_heat_x2_state: %s' % device.hvac_alt_heat_x2_state
+            print '            hvac_emer_heat_state  : %s' % device.hvac_emer_heat_state
+
+            print '            online                : %s' % device.online
+            print '            last_ip               : %s' % device.last_ip
+            print '            local_ip              : %s' % device.local_ip
+            print '            last_connection       : %s' % device.last_connection
+
+            print '            error_code            : %s' % device.error_code
+            print '            battery_level         : %s' % device.battery_level
+
     # The Nest object can also be used as a context manager
     with nest.Nest(username, password) as napi:
         for device in napi.devices:

--- a/nest/nest.py
+++ b/nest/nest.py
@@ -448,7 +448,7 @@ class Structure(NestBase):
         self._set_away(value)
 
     @property
-    def county_code(self):
+    def country_code(self):
         return self._structure['country_code']
 
     @property

--- a/nest/nest.py
+++ b/nest/nest.py
@@ -462,14 +462,6 @@ class Structure(NestBase):
         self._set('structure', {'name': value})
 
     @property
-    def location(self):
-        return self._structure['location']
-
-    @property
-    def address(self):
-        return self._structure['street_address']
-
-    @property
     def postal_code(self):
         return self._structure['postal_code']
 

--- a/nest/nest.py
+++ b/nest/nest.py
@@ -448,10 +448,42 @@ class Structure(NestBase):
         self._set_away(value)
 
     @property
+    def county_code(self):
+        return self._structure['country_code']
+
+    @property
     def devices(self):
         return [Device(devid.lstrip('device.'), self._nest_api,
                        self._local_time)
                 for devid in self._structure['devices']]
+
+    @property
+    def dr_reminder_enabled(self):
+        return self._structure['dr_reminder_enabled']
+
+    @property
+    def emergency_contact_description(self):
+        return self._structure['emergency_contact_description']
+
+    @property
+    def emergency_contact_type(self):
+        return self._structure['emergency_contact_type']
+
+    @property
+    def enhanced_auto_away_enabled(self):
+        return self._structure['topaz_enhanced_auto_away_enabled']
+
+    @property
+    def eta_preconditioning_active(self):
+        return self._structure['eta_preconditioning_active']
+
+    @property
+    def house_type(self):
+        return self._structure['house_type']
+
+    @property
+    def hvac_safety_shutoff_enabled(self):
+        return self._structure['hvac_safety_shutoff_enabled']
 
     @property
     def name(self):
@@ -462,8 +494,28 @@ class Structure(NestBase):
         self._set('structure', {'name': value})
 
     @property
+    def num_thermostats(self):
+        return self._structure['num_thermostats']
+
+    @property
+    def measurement_scale(self):
+        return self._structure['measurement_scale']
+
+    @property
     def postal_code(self):
         return self._structure['postal_code']
+
+    @property
+    def renovation_date(self):
+        return self._structure['renovation_date']
+
+    @property
+    def structure_area(self):
+        return self._structure['structure_area']
+
+    @property
+    def time_zone(self):
+        return self._structure['time_zone']
 
     @property
     def _wheres(self):

--- a/nest/nest.py
+++ b/nest/nest.py
@@ -282,6 +282,10 @@ class Device(NestBase):
         return self._nest_api._status['link'][self._serial]
 
     @property
+    def _track(self):
+        return self._nest_api._status['track'][self._serial]
+
+    @property
     def structure(self):
         return Structure(self._link['structure'].lstrip('structure.'),
                          self._nest_api, self._local_time)
@@ -359,6 +363,66 @@ class Device(NestBase):
     @name.setter
     def name(self, value):
         self._set('shared', {'name': value})
+
+    @property
+    def hvac_ac_state(self):
+        return self._shared['hvac_ac_state']
+
+    @property
+    def hvac_cool_x2_state(self):
+        return self._shared['hvac_cool_x2_state']
+
+    @property
+    def hvac_heater_state(self):
+        return self._shared['hvac_heater_state']
+
+    @property
+    def hvac_aux_heater_state(self):
+        return self._shared['hvac_aux_heater_state']
+
+    @property
+    def hvac_heat_x2_state(self):
+        return self._shared['hvac_heat_x2_state']
+
+    @property
+    def hvac_heat_x3_state(self):
+        return self._shared['hvac_heat_x3_state']
+
+    @property
+    def hvac_alt_heat_state(self):
+        return self._shared['hvac_alt_heat_state']
+
+    @property
+    def hvac_alt_heat_x2_state(self):
+        return self._shared['hvac_alt_heat_x2_state']
+
+    @property
+    def hvac_emer_heat_state(self):
+        return self._shared['hvac_emer_heat_state']
+
+    @property
+    def online(self):
+        return self._track['online']
+
+    @property
+    def local_ip(self):
+        return self._device['local_ip']
+
+    @property
+    def last_ip(self):
+        return self._track['last_ip']
+
+    @property
+    def last_connection(self):
+        return self._track['last_connection']
+
+    @property
+    def error_code(self):
+        return self._device['error_code']
+
+    @property
+    def battery_level(self):
+        return self._device['battery_level']
 
     @property
     def postal_code(self):

--- a/nest/nest.py
+++ b/nest/nest.py
@@ -534,6 +534,10 @@ class Structure(NestBase):
         return self._structure['emergency_contact_type']
 
     @property
+    def emergency_contact_phone(self):
+        return self._structure['emergency_contact_phone']
+
+    @property
     def enhanced_auto_away_enabled(self):
         return self._structure['topaz_enhanced_auto_away_enabled']
 

--- a/nest/utils.py
+++ b/nest/utils.py
@@ -8,6 +8,7 @@ _THIRTYTWO = decimal.Decimal(32)
 _ONEPOINTEIGHT = decimal.Decimal(18) / decimal.Decimal(10)
 _TENPOINTSEVENSIXFOUR = decimal.Decimal(10764) / decimal.Decimal(1000)
 
+
 def f_to_c(temp):
     temp = decimal.Decimal(temp)
     return float((temp - _THIRTYTWO) / _ONEPOINTEIGHT)

--- a/nest/utils.py
+++ b/nest/utils.py
@@ -6,7 +6,7 @@ CELSIUS = 'C'
 FAHRENHEIT = 'F'
 _THIRTYTWO = decimal.Decimal(32)
 _ONEPOINTEIGHT = decimal.Decimal(18) / decimal.Decimal(10)
-
+_TENPOINTSEVENSIXFOUR = decimal.Decimal(10764) / decimal.Decimal(1000)
 
 def f_to_c(temp):
     temp = decimal.Decimal(temp)
@@ -16,3 +16,13 @@ def f_to_c(temp):
 def c_to_f(temp):
     temp = decimal.Decimal(temp)
     return float(temp * _ONEPOINTEIGHT + _THIRTYTWO)
+
+
+def ft2_to_m2(area):
+    area = decimal.Decimal(area)
+    return float(area / _TENPOINTSEVENSIXFOUR)
+
+
+def m2_to_ft2(area):
+    area = decimal.Decimal(area)
+    return float(area * _TENPOINTSEVENSIXFOUR)


### PR DESCRIPTION
Remove two structure properties that do not exist (location & address) and cause exceptions. Add advanced structure and device properties (read-only) to Structure/Device classes. 
Update README with examples to access advanced structure and devices properties.