### PR TITLE
Fixed bug removing lstrip, using split to prevent characters being re…

### DIFF
--- a/nest/nest.py
+++ b/nest/nest.py
@@ -298,7 +298,7 @@ class Device(NestBase):
 
     @property
     def structure(self):
-        return Structure(self._link['structure'].lstrip('structure.'),
+        return Structure(self._link['structure'].split('.')[-1],
                          self._nest_api, self._local_time)
 
     @property


### PR DESCRIPTION
I found a bug in the Structure creation on the devices.  Using lstrip will remove not just the 'structure.' string from the beginning, but any characters contained in that string from the beginning, thus it will remove those letters from the beginning of the serial ID of the structure.  The serial ID commonly begins with letters and one I found beginning with 'c' had the 'c' stripped from it causing errors.  There are two other calls to lstrip used to remove 'device.' from the beginning of device serial IDs.  As far as I can tell, the device serial IDs always begin with numbers, so this shouldn't be an issue.  However, if there is a chance these could begin with letters, we might want to consider using the split('.')[-1] substitution.  This seemed like the simplest approach.  I did look at using regular expressions, which is arguably more explicit. 
We could also do something like this:
```python
import re
"""..."""
re.sub('structure.', '', self._link['structure'])
"""..."""
```
Let me know what you think.  Thanks!