### PR TITLE
Be more defensive processing response

### DIFF
--- a/nest/nest.py
+++ b/nest/nest.py
@@ -810,13 +810,13 @@ class Structure(NestBase):
     def devices(self):
         return [Device(devid.split('.')[-1], self._nest_api,
                        self._local_time)
-                for devid in self._structure['devices']]
+                for devid in self._structure.get('devices', [])]
 
     @property
     def protectdevices(self):
         return [ProtectDevice(topazid.split('.')[-1], self._nest_api,
                               self._local_time)
-                for topazid in self._nest_api._status['topaz']]
+                for topazid in self._nest_api._status.get('topaz', [])]
 
     @property
     def dr_reminder_enabled(self):


### PR DESCRIPTION
When a user does not have Nest Protect devices, requesting the nest protect devices resulted in a key error:

```
Traceback (most recent call last):
[…]
    for device in structure.protectdevices:
  File ".home-assistant/deps/nest/nest.py", line 819, in protectdevices
    for topazid in self._nest_api._status['topaz']]
KeyError: 'topaz'
```

[Traceback from report here](https://github.com/home-assistant/home-assistant/issues/2117#issuecomment-220660818)

This fix will make sure that we return an empty list instead of an error when either key is omitted from API response.