### PR TITLE
Master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ nosetests.xml
 .pydevproject
 
 MANIFEST
+
+# PyCharm
+.idea/*

--- a/nest/__init__.py
+++ b/nest/__init__.py
@@ -5,4 +5,6 @@ from .nest import Nest
 from .utils import CELSIUS
 from .utils import FAHRENHEIT
 
-__all__ = ['CELSIUS', 'FAHRENHEIT', 'Nest']
+from .helpers import nest_login
+
+__all__ = ['CELSIUS', 'FAHRENHEIT', 'Nest', 'nest_login']

--- a/nest/command_line.py
+++ b/nest/command_line.py
@@ -15,6 +15,7 @@ import sys
 
 from . import nest
 from . import utils
+from . import helpers
 
 
 def parse_args():
@@ -28,15 +29,7 @@ def parse_args():
 
     args, remaining_argv = conf_parser.parse_known_args()
 
-    defaults = {'celsius': False}
-    config_file = os.path.expanduser(args.conf)
-    if os.path.exists(config_file):
-        config = configparser.SafeConfigParser()
-        config.read([config_file])
-        if config.has_section('nest'):
-            defaults.update(dict(config.items('nest')))
-        else:
-            defaults.update(dict(config.items('DEFAULT')))
+    defaults = helpers.get_config(config_path=args.conf)
 
     description = 'Command line interface to Nest™ Thermostats'
     parser = argparse.ArgumentParser(description=description,

--- a/nest/command_line.py
+++ b/nest/command_line.py
@@ -8,8 +8,6 @@ nest.py -- a python interface to the Nest Thermostats
 from __future__ import print_function
 
 import argparse
-# use six for python2/python3 compatibility
-from six.moves import configparser
 import os
 import sys
 

--- a/nest/helpers.py
+++ b/nest/helpers.py
@@ -44,7 +44,8 @@ def nest_login(config_path=None, username=None, password=None, **kwargs):
     authentication credentials either provided as keyword arguments
     or read from the configuration file.
 
-    :param config_path: Path to the config file. The default is used if none is provided.
+    :param config_path: Path to the config file.
+        The default is used if none is provided.
         Optional if the the credentials are provided as arguments.
     :param username: Optional if the config file contains the username.
     :param password: Optional if the config file contains the password.

--- a/nest/helpers.py
+++ b/nest/helpers.py
@@ -2,10 +2,17 @@
 # a module of helper functions
 # mostly for the configuration
 
+import contextlib
 import os
+
+from . import nest
 
 # use six for python2/python3 compatibility
 from six.moves import configparser
+
+
+class MissingCredentialsError(ValueError):
+    pass
 
 
 def get_config(config_path=None, prog='nest'):
@@ -28,3 +35,33 @@ def get_auth_credentials(config_path=None):
     username = config.get('user')
     password = config.get('password')
     return username, password
+
+
+@contextlib.contextmanager
+def nest_login(config_path=None, username=None, password=None, **kwargs):
+    """
+    This a context manager for creating a Nest object using
+    authentication credentials either provided as keyword arguments
+    or read from the configuration file.
+
+    :param config_path: Path to the config file. The default is used if none is provided.
+        Optional if the the credentials are provided as arguments.
+    :param username: Optional if the config file contains the username.
+    :param password: Optional if the config file contains the password.
+    :param kwargs: Keyword arguments to pass onto the Nest initializer.
+    :return: Nest object
+    """
+
+    credentials_config = get_auth_credentials(config_path)
+    if not username:
+        username = credentials_config[0]
+    if not password:
+        password = credentials_config[1]
+
+    if username and password:
+        yield nest.Nest(username, password, **kwargs)
+    else:
+        raise MissingCredentialsError(
+            'The login credentials have not been provided.')
+
+

--- a/nest/helpers.py
+++ b/nest/helpers.py
@@ -7,6 +7,7 @@ import os
 # use six for python2/python3 compatibility
 from six.moves import configparser
 
+
 def get_config(config_path=None, prog='nest'):
     if not config_path:
         config_path = os.path.sep.join(('~', '.config', prog, 'config'))
@@ -21,10 +22,9 @@ def get_config(config_path=None, prog='nest'):
 
     return defaults
 
+
 def get_auth_credentials(config_path=None):
     config = get_config(config_path)
     username = config.get('user')
     password = config.get('password')
     return username, password
-
-

--- a/nest/helpers.py
+++ b/nest/helpers.py
@@ -64,5 +64,3 @@ def nest_login(config_path=None, username=None, password=None, **kwargs):
     else:
         raise MissingCredentialsError(
             'The login credentials have not been provided.')
-
-

--- a/nest/helpers.py
+++ b/nest/helpers.py
@@ -1,0 +1,30 @@
+# -*- coding:utf-8 -*-
+# a module of helper functions
+# mostly for the configuration
+
+import os
+
+# use six for python2/python3 compatibility
+from six.moves import configparser
+
+def get_config(config_path=None, prog='nest'):
+    if not config_path:
+        config_path = os.path.sep.join(('~', '.config', prog, 'config'))
+
+    defaults = {'celsius': False}
+    config_file = os.path.expanduser(config_path)
+    if os.path.exists(config_file):
+        config = configparser.SafeConfigParser()
+        config.read([config_file])
+        if config.has_section('nest'):
+            defaults.update(dict(config.items('nest')))
+
+    return defaults
+
+def get_auth_credentials(config_path=None):
+    config = get_config(config_path)
+    username = config.get('user')
+    password = config.get('password')
+    return username, password
+
+


### PR DESCRIPTION
The config parsing routine was moved to a new separate module, called helpers.py (I considered adding it to utils.py, but that module seems dedicated to unit conversions and other mathematical operations). 

This move makes the config parsing function available independently from the command line script. This can make it more convenient to build applications using this package, as login credentials may be read from an already existing configuration file (or stored there for future use). For example:

```
from nest import Nest, get_auth_credentials

username, password = get_auth_credentials(…)

if username and password:
    nest = Nest(username, password)
else:
    # request credentials
    …
```

Potentially, this module can be integrated into the existing Nest class in the nest.py module, where the username and password arguments can be made optional. However, I didn’t want to change the existing structure of nest.py at this stage in case there are objections to my proposed reorganisation.