### PR TITLE
nest: Default to time.time() for Forecast

### DIFF
--- a/nest/nest.py
+++ b/nest/nest.py
@@ -202,7 +202,8 @@ class Forecast(object):
         self._time = float(fget('observation_time',
                                 fget('time',
                                      fget('date',
-                                          fget('observation_epoch')))))
+                                          fget('observation_epoch',
+                                               time.time())))))
 
     def __repr__(self):
         return '<%s: %s>' % (self.__class__.__name__,


### PR DESCRIPTION
Previously if a forcast entry did not have any of listed keys it
returned `None` which would fail in the `float()` wrapper. Default to
`time.time()` if the data fragment doesn't contain any of out wanted
keys.

Fixes: #47