### PR TITLE
Update nest.py (add Device.schedule attribute)

### DIFF
--- a/nest/nest.py
+++ b/nest/nest.py
@@ -561,6 +561,25 @@ class Device(NestBase):
     def hot_water_temperature(self):
         return self._device['hot_water_temperature']
 
+    ''' Create schedule atttibute
+        Creates a list of setpoint lists.  Setpoint lists formatted as [weekday, setpoint_num, time(seconds), temp(C), type]
+    '''
+    @property
+    def schedule(self):
+        dev_sched = self._nest_api._cache[0]['schedule'][self._device['serial_number']]
+        schedule = []
+        setpoint = []
+        for day in dev_sched['days']:
+            for n in range(10):
+                try:
+                    if dev_sched['days'][str(day)][str(n)]['entry_type'] == 'setpoint':
+                        setpoint = [int(day), n, dev_sched['days'][str(day)][str(n)]['time'], dev_sched['days'][str(day)][str(n)]['temp'], dev_sched['days'][str(day)][str(n)]['type']]
+                        schedule.append(setpoint)
+                        setpoint = []
+                except:
+                    pass
+                
+        return schedule   
 
 class ProtectDevice(NestBase):
     @property


### PR DESCRIPTION
This request adds a schedule attribute to the Device class to expose user-scheduled setpoints in the api.  It creates an instance object that is a list of setpoint lists where each setpoint element is formatted as: [weekday, setpoint_num, time(seconds), temp(C), type]

Note that my python skills are not very advanced so please review carefully.
