### PR TITLE
Bump version to 3.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 #                Bumping Minor means API bugfix or new functionality.
 #                Bumping Micro means CLI change of any kind unless it is
 #                    significant enough to warrant a minor/major bump.
-version = '3.0.5'
+version = '3.1.0'
 
 
 setup(name='python-nest',


### PR DESCRIPTION
A reminder to not submit PR's before coffee (#73).

We've had a few bug fixes and more functionality. According to `setup.py`, "Bumping Minor means API bugfix or new functionality".

I also selfishly just want to cut a release so that I can close out home-assistant/home-assistant#5693.