### PR TITLE
CLI Fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,7 +147,7 @@ You can import the module as `nest`.
 
 
 
-FIXME In the API, temperatures are in  all temperature values are in degrees celsius. Helper functions
+FIXME In the API, all temperature values are in degrees celsius. Helper functions
 for conversion are in the `utils` module:
 
 .. code-block:: python
@@ -223,13 +223,13 @@ A configuration file must be specified and used for the credentials to communica
 
 .. code-block:: ini
 
-    [DEFAULT]
+    [NEST]
     user = joe@user.com
     password = swordfish
-    token_cache = ~/.config/nest/cache
+    token_cache = ~/.config/nest/token_cache
 
 
-The `[DEFAULT]` section may also be named `[nest]` for convenience.
+The `[NEST]` section may also be named `[nest]` for convenience. Do not use `[DEFAULT]` as it cannot be read
 
 
 History

--- a/nest/command_line.py
+++ b/nest/command_line.py
@@ -287,7 +287,7 @@ def main():
             if device.has_hot_water_control:
                 print('Hot Water Temp        : %s' % device.fan)
             print('Temp                  : %0.1f%s' %
-                 (device.temperature, device.temperature_scale))
+                  (device.temperature, device.temperature_scale))
             print('Humidity              : %0.1f%%' % device.humidity)
             if isinstance(device.target, tuple):
                 print('Target                 : %0.1f-%0.1f%s' % (
@@ -296,7 +296,7 @@ def main():
                     device.temperature_scale))
             else:
                 print('Target                : %0.1f%s' %
-                     (display_temp(device.target), device.temperature_scale))
+                      (display_temp(device.target), device.temperature_scale))
             print('Away Heat             : %0.1fC' % device.eco_temperature[0])
             print('Away Cool             : %0.1fC' % device.eco_temperature[1])
             print('Has Leaf              : %s' % device.has_leaf)

--- a/nest/command_line.py
+++ b/nest/command_line.py
@@ -149,9 +149,9 @@ def main():
     if not os.path.exists(token_cache):
         if args.client_id is None or args.client_secret is None:
             print("Missing client and secret. If using a configuration file,"
-                  " ensure that it is formatted properly, with a section titled"
-                  " as per the documentation-otherwise, call with --client-id "
-                  "and --client-secret.")
+                  " ensure that it is formatted properly, with a section "
+                  "titled as per the documentation-otherwise, call with "
+                  "--client-id and --client-secret.")
             return
 
     with nest.Nest(client_id=args.client_id, client_secret=args.client_secret,

--- a/nest/command_line.py
+++ b/nest/command_line.py
@@ -16,18 +16,20 @@ from . import nest
 from . import utils
 from . import helpers
 
+# use six for python2/python3 compatibility
+from six.moves import input
+
 
 def parse_args():
     # Get Executable name
     prog = os.path.basename(sys.argv[0])
 
-    config_file = os.path.expanduser('~/config/nest/config')
+    config_file = os.path.expanduser('~/.config/nest/config')
 
     token_cache = os.path.sep.join(('~', '.config', 'nest', 'token_cache'))
 
     conf_parser = argparse.ArgumentParser(prog=prog, add_help=False)
 
-    # This isn't working
     conf_parser.add_argument('--conf', default=config_file,
                              help='config file (default %s)' % config_file,
                              metavar='FILE')
@@ -72,8 +74,9 @@ def parse_args():
     subparsers = parser.add_subparsers(dest='command',
                                        help='command help')
     temp = subparsers.add_parser('temp', help='show/set temperature')
+
     temp.add_argument('temperature', nargs='*', type=float,
-                      help='target tempterature to set device to')
+                      help='target temperature to set device to')
 
     fan = subparsers.add_parser('fan', help='set fan "on" or "auto"')
     fan_group = fan.add_mutually_exclusive_group()
@@ -142,12 +145,12 @@ def main():
     # This is the command(s) passed to the command line utility
     cmd = args.command
 
-    if not os.path.exists(args.conf):
-        if args.client_id is None or args.client_secret is None:
-            print("Missing client and secret. Either call with --client-id "
-                  "and --client-secret or add to config as client_id and "
-                  "client_secret")
-            return
+    if args.client_id is None or args.client_secret is None:
+        print("Missing client and secret. If using a configuration file,"
+              " ensure that it is formatted properly, with a section titled"
+              " as per the documentation-otherwise, call with --client-id "
+              "and --client-secret.")
+        return
 
     token_cache = os.path.expanduser(args.token_cache)
 
@@ -158,10 +161,7 @@ def main():
         if napi.authorization_required:
             print('Go to ' + napi.authorize_url +
                   ' to authorize, then enter PIN below')
-            if sys.version_info[0] < 3:
-                pin = raw_input("PIN: ")
-            else:
-                pin = input("PIN: ")
+            pin = input("PIN: ")
             napi.request_token(pin)
 
         if cmd == 'away':
@@ -286,8 +286,8 @@ def main():
             print('Has Hot Water Control : %s' % device.has_hot_water_control)
             if device.has_hot_water_control:
                 print('Hot Water Temp        : %s' % device.fan)
-            print('Temp                  : %0.1f%s' %
-                  (device.temperature, device.temperature_scale))
+            print('Temp                  : %0.1f%s' % (device.temperature,
+                device.temperature_scale))
             print('Humidity              : %0.1f%%' % device.humidity)
             if isinstance(device.target, tuple):
                 print('Target                 : %0.1f-%0.1f%s' % (
@@ -295,8 +295,8 @@ def main():
                     display_temp(device.target[1]),
                     device.temperature_scale))
             else:
-                print('Target                : %0.1f%s' %
-                      (display_temp(device.target), device.temperature_scale))
+                print('Target                : %0.1f%s' % \
+                (display_temp(device.target), device.temperature_scale))
             print('Away Heat             : %0.1fC' % device.eco_temperature[0])
             print('Away Cool             : %0.1fC' % device.eco_temperature[1])
             print('Has Leaf              : %s' % device.has_leaf)

--- a/nest/command_line.py
+++ b/nest/command_line.py
@@ -286,8 +286,8 @@ def main():
             print('Has Hot Water Control : %s' % device.has_hot_water_control)
             if device.has_hot_water_control:
                 print('Hot Water Temp        : %s' % device.fan)
-            print('Temp                  : %0.1f%s' % (device.temperature,
-                    device.temperature_scale))
+            print('Temp                  : %0.1f%s' %
+                 (device.temperature, device.temperature_scale))
             print('Humidity              : %0.1f%%' % device.humidity)
             if isinstance(device.target, tuple):
                 print('Target                 : %0.1f-%0.1f%s' % (
@@ -296,7 +296,7 @@ def main():
                     device.temperature_scale))
             else:
                 print('Target                : %0.1f%s' %
-                        (display_temp(device.target), device.temperature_scale))
+                     (display_temp(device.target), device.temperature_scale))
             print('Away Heat             : %0.1fC' % device.eco_temperature[0])
             print('Away Cool             : %0.1fC' % device.eco_temperature[1])
             print('Has Leaf              : %s' % device.has_leaf)

--- a/nest/command_line.py
+++ b/nest/command_line.py
@@ -287,7 +287,7 @@ def main():
             if device.has_hot_water_control:
                 print('Hot Water Temp        : %s' % device.fan)
             print('Temp                  : %0.1f%s' % (device.temperature,
-                device.temperature_scale))
+                    device.temperature_scale))
             print('Humidity              : %0.1f%%' % device.humidity)
             if isinstance(device.target, tuple):
                 print('Target                 : %0.1f-%0.1f%s' % (
@@ -295,8 +295,8 @@ def main():
                     display_temp(device.target[1]),
                     device.temperature_scale))
             else:
-                print('Target                : %0.1f%s' % \
-                (display_temp(device.target), device.temperature_scale))
+                print('Target                : %0.1f%s' %
+                    (display_temp(device.target), device.temperature_scale))
             print('Away Heat             : %0.1fC' % device.eco_temperature[0])
             print('Away Cool             : %0.1fC' % device.eco_temperature[1])
             print('Has Leaf              : %s' % device.has_leaf)

--- a/nest/command_line.py
+++ b/nest/command_line.py
@@ -287,7 +287,7 @@ def main():
             if device.has_hot_water_control:
                 print('Hot Water Temp        : %s' % device.fan)
             print('Temp                  : %0.1f%s' % (device.temperature,
-                device.temperature_scale))
+                  device.temperature_scale))
             print('Humidity              : %0.1f%%' % device.humidity)
             if isinstance(device.target, tuple):
                 print('Target                 : %0.1f-%0.1f%s' % (
@@ -295,8 +295,8 @@ def main():
                     display_temp(device.target[1]),
                     device.temperature_scale))
             else:
-                print('Target                : %0.1f%s' % \
-                (display_temp(device.target), device.temperature_scale))
+                print('Target                : %0.1f%s' %
+                      (display_temp(device.target), device.temperature_scale))
             print('Away Heat             : %0.1fC' % device.eco_temperature[0])
             print('Away Cool             : %0.1fC' % device.eco_temperature[1])
             print('Has Leaf              : %s' % device.has_leaf)

--- a/nest/command_line.py
+++ b/nest/command_line.py
@@ -24,8 +24,7 @@ def parse_args():
     # Get Executable name
     prog = os.path.basename(sys.argv[0])
 
-    config_file = os.path.expanduser('~/.config/nest/config')
-
+    config_file = os.path.sep.join(('~', '.config', 'nest', 'config'))
     token_cache = os.path.sep.join(('~', '.config', 'nest', 'token_cache'))
 
     conf_parser = argparse.ArgumentParser(prog=prog, add_help=False)

--- a/nest/command_line.py
+++ b/nest/command_line.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 import argparse
 import os
 import sys
+import errno
 
 from . import nest
 from . import utils
@@ -22,7 +23,6 @@ def parse_args():
 
     config_file = os.path.expanduser('~/config/nest/config')
 
-    #config_file = os.path.sep.join(('~', '.config', 'nest', 'config'))
     token_cache = os.path.sep.join(('~', '.config', 'nest', 'token_cache'))
 
     conf_parser = argparse.ArgumentParser(prog=prog, add_help=False)
@@ -287,7 +287,7 @@ def main():
             if device.has_hot_water_control:
                 print('Hot Water Temp        : %s' % device.fan)
             print('Temp                  : %0.1f%s' % (device.temperature,
-                                          device.temperature_scale))
+                device.temperature_scale))
             print('Humidity              : %0.1f%%' % device.humidity)
             if isinstance(device.target, tuple):
                 print('Target                 : %0.1f-%0.1f%s' % (
@@ -295,8 +295,8 @@ def main():
                     display_temp(device.target[1]),
                     device.temperature_scale))
             else:
-                print('Target                : %0.1f%s' % (display_temp(device.target),
-                                              device.temperature_scale))
+                print('Target                : %0.1f%s' % \
+                (display_temp(device.target), device.temperature_scale))
             print('Away Heat             : %0.1fC' % device.eco_temperature[0])
             print('Away Cool             : %0.1fC' % device.eco_temperature[1])
             print('Has Leaf              : %s' % device.has_leaf)

--- a/nest/command_line.py
+++ b/nest/command_line.py
@@ -144,14 +144,15 @@ def main():
     # This is the command(s) passed to the command line utility
     cmd = args.command
 
-    if args.client_id is None or args.client_secret is None:
-        print("Missing client and secret. If using a configuration file,"
-              " ensure that it is formatted properly, with a section titled"
-              " as per the documentation-otherwise, call with --client-id "
-              "and --client-secret.")
-        return
-
     token_cache = os.path.expanduser(args.token_cache)
+
+    if not os.path.exists(token_cache):
+        if args.client_id is None or args.client_secret is None:
+            print("Missing client and secret. If using a configuration file,"
+                  " ensure that it is formatted properly, with a section titled"
+                  " as per the documentation-otherwise, call with --client-id "
+                  "and --client-secret.")
+            return
 
     with nest.Nest(client_id=args.client_id, client_secret=args.client_secret,
                    access_token=args.token,

--- a/nest/command_line.py
+++ b/nest/command_line.py
@@ -296,7 +296,7 @@ def main():
                     device.temperature_scale))
             else:
                 print('Target                : %0.1f%s' %
-                    (display_temp(device.target), device.temperature_scale))
+                        (display_temp(device.target), device.temperature_scale))
             print('Away Heat             : %0.1fC' % device.eco_temperature[0])
             print('Away Cool             : %0.1fC' % device.eco_temperature[1])
             print('Has Leaf              : %s' % device.has_leaf)

--- a/nest/helpers.py
+++ b/nest/helpers.py
@@ -30,6 +30,9 @@ def get_config(config_path=None, prog='nest'):
             defaults.update(dict(config.items('nest')))
         elif config.has_section('NEST'):
             defaults.update(dict(config.items('NEST')))
+        else:
+            print ('Incorrectly formatted configuration file.')
+            exit()
 
     return defaults
 

--- a/nest/helpers.py
+++ b/nest/helpers.py
@@ -31,7 +31,7 @@ def get_config(config_path=None, prog='nest'):
         elif config.has_section('NEST'):
             defaults.update(dict(config.items('NEST')))
         else:
-            print ('Incorrectly formatted configuration file.')
+            print('Incorrectly formatted configuration file.')
             exit()
 
     return defaults

--- a/nest/helpers.py
+++ b/nest/helpers.py
@@ -21,11 +21,15 @@ def get_config(config_path=None, prog='nest'):
 
     defaults = {'celsius': False}
     config_file = os.path.expanduser(config_path)
+
+    # Note, this cannot accept sections titled 'DEFAULT'
     if os.path.exists(config_file):
         config = configparser.SafeConfigParser()
         config.read([config_file])
         if config.has_section('nest'):
             defaults.update(dict(config.items('nest')))
+        elif config.has_section('NEST'):
+            defaults.update(dict(config.items('NEST')))
 
     return defaults
 


### PR DESCRIPTION
- Fixes #90 
- Adds additional features to command line tool `show` argument
- Removes the requirement to manually create `~/.config/nest` directory (automatically created now)
- Fixes the PIN prompt so it uses six.moves for compatibility

I've started adding comments to some of the code-if this is an issue, please let me know.

Cheers!

Signed-off-by: Troy Fontaine <tfontaine@troyfontaine.com>