### PR TITLE
Add support for 'previous_hvac_mode'

### DIFF
--- a/nest/nest.py
+++ b/nest/nest.py
@@ -608,6 +608,10 @@ class Thermostat(Device):
         # data['eco']['mode_update_timestamp'] = time.time()
         # self._set('device', data)
 
+    @property
+    def previous_mode(self):
+        return self._device.get('previous_hvac_mode')
+
 
 class SmokeCoAlarm(Device):
     @property


### PR DESCRIPTION
This allows for easier transitions out of 'eco' mode and back to the previous mode ([Nest API reference](https://developers.nest.com/documentation/cloud/api-thermostat#previous_hvac_mode)).