### PR TITLE
cli: pass in a value not a list

### DIFF
--- a/nest/command_line.py
+++ b/nest/command_line.py
@@ -289,7 +289,7 @@ def main():
                     device.temperature = args.temperature
 
                 else:
-                    device.temperature = args.temperature
+                    device.temperature = args.temperature[0]
 
             print('%0.1f' % display_temp(device.temperature))
 


### PR DESCRIPTION
args.temperature will always be a list, however if the device is not in
range mode, the library expects a single value.