### PR TITLE
cli: gaurd against None in string formatting

### DIFF
--- a/nest/command_line.py
+++ b/nest/command_line.py
@@ -362,8 +362,15 @@ def main():
             else:
                 print('Target                : %0.1f%s' %
                       (display_temp(device.target), device.temperature_scale))
-            print('Away Heat             : %0.1fC' % device.eco_temperature[0])
-            print('Away Cool             : %0.1fC' % device.eco_temperature[1])
+
+            if (device.eco_temperature[0]):
+                print('Away Heat             : %0.1fC' %
+                      device.eco_temperature[0])
+
+            if (device.eco_temperature[1]):
+                print('Away Cool             : %0.1fC' %
+                      device.eco_temperature[1])
+
             print('Has Leaf              : %s' % device.has_leaf)
 
 


### PR DESCRIPTION
sometimes eco_temperature isn't in the api, so its property's value is
``None``. But string formatting that is no bueno. Wraps the display in
a guard to prevent tracebacks.

Fixes: #104