### PR TITLE
cli: wrap prints

### DIFF
--- a/nest/command_line.py
+++ b/nest/command_line.py
@@ -353,7 +353,8 @@ def main():
                 print('Hot Water Temp        : %s' % device.fan)
             print('Temp                  : %0.1f%s' % (device.temperature,
                   device.temperature_scale))
-            print('Humidity              : %0.1f%%' % device.humidity)
+            helpers.print_if('Humidity              : %0.1f%%',
+                             device.humidity)
             if isinstance(device.target, tuple):
                 print('Target                 : %0.1f-%0.1f%s' % (
                     display_temp(device.target[0]),
@@ -363,13 +364,11 @@ def main():
                 print('Target                : %0.1f%s' %
                       (display_temp(device.target), device.temperature_scale))
 
-            if (device.eco_temperature[0]):
-                print('Away Heat             : %0.1fC' %
-                      device.eco_temperature[0])
+            helpers.print_if('Away Heat             : %0.1fC',
+                             device.eco_temperature[0])
 
-            if (device.eco_temperature[1]):
-                print('Away Cool             : %0.1fC' %
-                      device.eco_temperature[1])
+            helpers.print_if('Away Cool             : %0.1fC',
+                             device.eco_temperature[1])
 
             print('Has Leaf              : %s' % device.has_leaf)
 

--- a/nest/helpers.py
+++ b/nest/helpers.py
@@ -2,6 +2,7 @@
 # a module of helper functions
 # mostly for the configuration
 
+from __future__ import print_function
 import contextlib
 import os
 
@@ -71,3 +72,8 @@ def nest_login(config_path=None, username=None, password=None, **kwargs):
     else:
         raise MissingCredentialsError(
             'The login credentials have not been provided.')
+
+
+def print_if(str, *fmt_args):
+    if all(fmt_args):
+        print(str % fmt_args)


### PR DESCRIPTION
Wrap printing of a few float values in ``print_if`` to prevent
tracebacks attemping to print ``None`` values as floats.

Fixes: #102