### PR TITLE
Don't raise KeyError in device.snapshot_url

### DIFF
--- a/nest/nest.py
+++ b/nest/nest.py
@@ -1286,7 +1286,8 @@ class Camera(Device):
 
     @property
     def snapshot_url(self):
-        if self._device['snapshot_url'] != SIMULATOR_SNAPSHOT_URL:
+        if ('snapshot_url' in self._device and
+                self._device['snapshot_url'] != SIMULATOR_SNAPSHOT_URL):
             return self._device['snapshot_url']
         else:
             return SIMULATOR_SNAPSHOT_PLACEHOLDER_URL


### PR DESCRIPTION
Was getting this error in Home Assistant when requesting the camera image:

```
  File "/Users/paulus/dev/python/home-assistant/homeassistant/components/camera/nest.py", line 98, in camera_image
    url = self.device.snapshot_url
  File "/Users/paulus/dev/python/home-assistant/lib/python3.6/site-packages/nest/nest.py", line 1289, in snapshot_url
    if self._device['snapshot_url'] != SIMULATOR_SNAPSHOT_URL:
KeyError: 'snapshot_url'
```

This patch makes the code more defensive by making sure the key exists.