### PR TITLE
Handle missing where names

### DIFF
--- a/nest/nest.py
+++ b/nest/nest.py
@@ -235,7 +235,12 @@ class Device(NestBase):
     @property
     def where(self):
         if self.where_id is not None:
-            return self.structure.wheres[self.where_id]['name']
+            # This name isn't always present due to upstream bug in the API
+            # https://nestdevelopers.io/t/missing-where-name-from-some-devices/1202
+            if self.where_id in self.structure.wheres:
+                return self.structure.wheres[self.where_id]['name']
+            else:
+                return self.where_id
 
     @property
     def where_id(self):


### PR DESCRIPTION
Due to an upstream bug some devices will be assigned a where_id that is not
visible in the API. As a result we can't get a friendly name for the where.

If we encounter a where_id with no associated name just return the id as
the name.

See https://nestdevelopers.io/t/missing-where-name-from-some-devices/1202

Fixes #127