### PR TITLE
Fix a thread race condition error may cause RuntimeError

### DIFF
--- a/nest/nest.py
+++ b/nest/nest.py
@@ -1781,9 +1781,7 @@ class Nest(object):
             self._open_data_stream("/")
         self._queue_lock.release()
 
-        self._queue_lock.acquire(False)
         value = self._queue[0]['data']
-        self._queue_lock.release()
         if not value:
             value = self._get("/")
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 #                Bumping Minor means API bugfix or new functionality.
 #                Bumping Micro means CLI change of any kind unless it is
 #                    significant enough to warrant a minor/major bump.
-version = '4.0.0'
+version = '4.0.1'
 
 
 setup(name='python-nest',


### PR DESCRIPTION
The `self._queue_lock.acquire(False)` usage was wrong. My intention here is create a read-only lock, however, not like other language, `acquire(False)` is not for this purpose. It will immediately return False if other thread already locked it. In that case, next `release()` may throw a RuntimError: release unlocked lock

Following is the stack trace I got today

```
Traceback (most recent call last):
  File "/home/jason/ha/home-assistant/homeassistant/helpers/entity_platform.py", line 129, in _async_setup_platform
    SLOW_SETUP_MAX_WAIT, loop=hass.loop)
  File "/usr/lib/python3.6/asyncio/tasks.py", line 358, in wait_for
    return fut.result()
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/jason/ha/home-assistant/homeassistant/components/binary_sensor/nest.py", line 93, in setup_platform
    for variable in conditions
  File "/home/jason/ha/home-assistant/homeassistant/components/binary_sensor/nest.py", line 95, in <listcomp>
    and device.is_thermostat]
  File "/home/jason/ha/home-assistant/homeassistant/components/sensor/nest.py", line 113, in __init__
    self._location = self.device.where
  File "/home/jason/ha/home-assistant/venv/lib/python3.6/site-packages/nest/nest.py", line 262, in where
    if self.where_id in self.structure.wheres:
  File "/home/jason/ha/home-assistant/venv/lib/python3.6/site-packages/nest/nest.py", line 1505, in wheres
    return self._structure['wheres']
  File "/home/jason/ha/home-assistant/venv/lib/python3.6/site-packages/nest/nest.py", line 1326, in _structure
    return self._nest_api._status[STRUCTURES][self._serial]
  File "/home/jason/ha/home-assistant/venv/lib/python3.6/site-packages/nest/nest.py", line 1786, in _status
    self._queue_lock.release()
RuntimeError: release unlocked lock
``` 