### PR TITLE
Fix configuration directives in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -293,8 +293,8 @@ A configuration file must be specified and used for the credentials to communica
 .. code-block:: ini
 
     [NEST]
-    client-id = your_client_id
-    client-secret = your_client_secret
+    client_id = your_client_id
+    client_secret = your_client_secret
     token_cache = ~/.config/nest/token_cache
 
 


### PR DESCRIPTION
`client-id` and `client-secret` in config file should be `client_id` and `client_secret` respectively.