### PR TITLE
Update for python3.10 moving Callable usage to collections.abc

### DIFF
--- a/nest/nest.py
+++ b/nest/nest.py
@@ -156,7 +156,7 @@ class NestAuth(auth.AuthBase):
 
     def _callback(self, res):
         if self.auth_callback is not None and isinstance(self.auth_callback,
-                                                         collections.Callable):
+                                                         collections.abc.Callable):
             self.auth_callback(res)
 
     def login(self, headers=None):


### PR DESCRIPTION
Update for python3.10 moving Callable usage to collections.abc, since this is a blocker for homeassistant moving to python3.10.  See https://github.com/home-assistant/core/pull/59729

I don't have any way to test this, since I don't have a works with nest account, so any review or testing would be appreciated.